### PR TITLE
Add Database Migration test

### DIFF
--- a/.github/workflows/azure-deploy-razor-app.yml
+++ b/.github/workflows/azure-deploy-razor-app.yml
@@ -64,7 +64,7 @@ jobs:
         shell: bash 
         run: |
           cd src/Chirp.Infrastructure/Chirp.Infrastructure.Repositories
-          dotnet ef migrations bundle -s ../../Chirp.Web -o ${{env.DOTNET_ROOT}}/migrate/bundle
+          ASPNETCORE_ENVIRONMENT=Production dotnet ef migrations bundle -s ../../Chirp.Web -o ${{env.DOTNET_ROOT}}/migrate/bundle
           
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4

--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Make target directory 
-        run: mkdir -p  ${{env.ArtifactPath}}/database
+        run: mkdir -p  $GITHUB_WORKSPACE/database
 
       - name: Install azure CLI and download database
         uses: Azure/CLI@v2
@@ -147,15 +147,15 @@ jobs:
             --account-key ${{ secrets.STORAGE_ACCOUNT_KEY }} \
             --share-name databases-fileshare \
             --path chirp.db \
-            --dest ${{env.ArtifactPath}}/database/chirp.db
+            --dest $GITHUB_WORKSPACE/database/chirp.db
           
-            ls ${{env.ArtifactPath}}/database
+            ls $GITHUB_WORKSPACE/database
       
       - name: Upload artifacts for test job
         uses: actions/upload-artifact@v4
         with:
           name: database
-          path: ${{env.ArtifactPath}}/database
+          path: $GITHUB_WORKSPACE/database
   
   Migration-Test: 
     name: Test database migration 

--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -4,6 +4,9 @@
 name: .Net Test
 on: [ push, workflow_call, workflow_dispatch ]
 
+env: 
+  ArtifactPath: /usr/share/ 
+
 permissions:
   contents: read
 
@@ -113,19 +116,19 @@ jobs:
       - name: Make directory
         shell: bash
         run: |
-              mkdir -p ${{env.DOTNET_ROOT}}/migrate
+              mkdir -p ${{env.ArtifactPath}}/migrate
       
       - name: Create Migration Bundle
         shell: bash 
         run: |
               cd src/Chirp.Infrastructure/Chirp.Infrastructure.Repositories
-              dotnet ef migrations bundle -s ../../Chirp.Web -o ${{env.DOTNET_ROOT}}/migrate/bundle
+              dotnet ef migrations bundle -s ../../Chirp.Web -o ${{env.ArtifactPath}}/migrate/bundle
             
       - name: Upload artifacts for test job
         uses: actions/upload-artifact@v4
         with:
           name: migration
-          path: ${{env.DOTNET_ROOT}}/migrate
+          path: ${{env.ArtifactPath}}/migrate
   
   Download-Database: 
     name: Download database from azure
@@ -139,15 +142,15 @@ jobs:
           inlinescript: |
             az storage file download --account-name ${{ secrets.STORAGE_ACCOUNT_NAME }} \
             --account-key ${{ secrets.STORAGE_ACCOUNT_KEY }} \
-            --share-name database-fileshare \
+            --share-name databases-fileshare \
             --path chirp.db \
-            --dest ${{env.DOTNET_ROOT}}/database
+            --dest ${{env.ArtifactPath}}/database
       
       - name: Upload artifacts for test job
         uses: actions/upload-artifact@v4
         with:
           name: database
-          path: ${{env.DOTNET_ROOT}}/database
+          path: ${{env.ArtifactPath}}/database
   
   Migration-Test: 
     name: Test database migration 

--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -122,7 +122,7 @@ jobs:
         shell: bash 
         run: |
               cd src/Chirp.Infrastructure/Chirp.Infrastructure.Repositories
-              dotnet ef migrations bundle -s ../../Chirp.Web -o ${{env.ArtifactPath}}/migrate/bundle
+              ASPNETCORE_ENVIRONMENT=Production dotnet ef migrations bundle -s ../../Chirp.Web -o ${{env.ArtifactPath}}/migrate/bundle
             
       - name: Upload artifacts for test job
         uses: actions/upload-artifact@v4
@@ -167,6 +167,7 @@ jobs:
       - name: Execute bundle 
         shell: bash
         run: |
+          chmod +x bundle
           ASPNETCORE_ENVIRONMENT=Production ./bundle --connection "Data Source=chirp.db"
       
       

--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Make target directory 
-        run: mkdir -p  $GITHUB_WORKSPACE/database
+        run: mkdir -p  ${{env.ArtifactPath}}/database
 
       - name: Install azure CLI and download database
         uses: Azure/CLI@v2
@@ -147,15 +147,20 @@ jobs:
             --account-key ${{ secrets.STORAGE_ACCOUNT_KEY }} \
             --share-name databases-fileshare \
             --path chirp.db \
-            --dest $GITHUB_WORKSPACE/database/chirp.db
-          
-            ls $GITHUB_WORKSPACE/database
+            --dest $GITHUB_WORKSPACE/chirp.db
       
+      - name: Copy database file
+        shell: bash
+        run: |
+          echo This Dir: 
+          ls 
+          cp chirp.db ${{env.ArtifactPath}}/database/chirp.db      
+
       - name: Upload artifacts for test job
         uses: actions/upload-artifact@v4
         with:
           name: database
-          path: $GITHUB_WORKSPACE/database
+          path: ${{env.ArtifactPath}}/database
   
   Migration-Test: 
     name: Test database migration 

--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -5,7 +5,7 @@ name: .Net Test
 on: [ push, workflow_call, workflow_dispatch ]
 
 env: 
-  ArtifactPath: /usr/share/ 
+  ArtifactPath: /usr/share
 
 permissions:
   contents: read

--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -147,7 +147,7 @@ jobs:
             --account-key ${{ secrets.STORAGE_ACCOUNT_KEY }} \
             --share-name databases-fileshare \
             --path chirp.db \
-            --dest ${{env.ArtifactPath}}/database
+            --dest ${{env.ArtifactPath}}/database/chirp.db
       
       - name: Upload artifacts for test job
         uses: actions/upload-artifact@v4

--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -96,7 +96,79 @@ jobs:
         GITHUBCLIENTID: ${{ secrets.GITHUBCLIENTID }}
         GITHUBCLIENTSECRET: ${{ secrets.GITHUBCLIENTSECRET }}
       run: dotnet test tests/Chirp.Web.UITest --no-build --verbosity normal
+
+  Setup-Migration: 
+    name: Database Migration Test
+    needs: setup-dotnet
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v4
+      
+      - name: Install dotnet-ef 
+        run: dotnet tool install --global dotnet-ef --version 9.0.0-rc.1.24451.1
+      
+      - name: Make directory
+        shell: bash
+        run: |
+              mkdir -p ${{env.DOTNET_ROOT}}/migrate
+      
+      - name: Create Migration Bundle
+        shell: bash 
+        run: |
+              cd src/Chirp.Infrastructure/Chirp.Infrastructure.Repositories
+              dotnet ef migrations bundle -s ../../Chirp.Web -o ${{env.DOTNET_ROOT}}/migrate/bundle
+            
+      - name: Upload artifacts for test job
+        uses: actions/upload-artifact@v4
+        with:
+          name: migration
+          path: ${{env.DOTNET_ROOT}}/migrate
   
-    
+  Download-Database: 
+    name: Download database from azure
+    runs-on: ubuntu-latest 
+    steps: 
+      - uses: actions/checkout@v4
+
+      - name: Install azure CLI 
+        uses: Azure/CLI@v2
+      
+      - name: Download database from Azure Storage
+        shell: bash
+        run: |
+          # Login to Azure Storage
+          az storage file download --account-name ${{ secrets.STORAGE_ACCOUNT_NAME }} \
+            --account-key ${{ secrets.STORAGE_ACCOUNT_KEY }} \
+            --share-name database-fileshare \
+            --path chirp.db \
+            --dest ${{env.DOTNET_ROOT}}/database
+
+      - name: Upload artifacts for test job
+        uses: actions/upload-artifact@v4
+        with:
+          name: database
+          path: ${{env.DOTNET_ROOT}}/database
+  
+  Migration-Test: 
+    name: Test database migration 
+    needs: [Download-Database, Setup-Migration]
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v4 
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+      
+      - name: Execute bundle 
+        shell: bash
+        run: |
+          ASPNETCORE_ENVIRONMENT=Production ./bundle --connection "Data Source=chirp.db"
+      
+      
+
+
+
         
         

--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -4,6 +4,9 @@
 name: .Net Test
 on: [ push, workflow_call, workflow_dispatch ]
 
+permissions:
+  contents: read
+
 jobs:
   setup-dotnet: 
     name: Setup dotnet

--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -148,6 +148,8 @@ jobs:
             --share-name databases-fileshare \
             --path chirp.db \
             --dest ${{env.ArtifactPath}}/database/chirp.db
+          
+            ls ${{env.ArtifactPath}}/database
       
       - name: Upload artifacts for test job
         uses: actions/upload-artifact@v4
@@ -167,6 +169,13 @@ jobs:
         with:
           merge-multiple: true
       
+      - name: Ensure database was uploaded 
+        shell: bash 
+        run: |
+          if ! [ -f chirp.db ]; then 
+            exit 1
+          fi
+
       - name: Execute bundle 
         shell: bash
         run: |

--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -98,7 +98,7 @@ jobs:
       run: dotnet test tests/Chirp.Web.UITest --no-build --verbosity normal
 
   Setup-Migration: 
-    name: Database Migration Test
+    name: Setup migration bundle
     needs: setup-dotnet
     runs-on: ubuntu-latest
     steps: 
@@ -130,19 +130,16 @@ jobs:
     steps: 
       - uses: actions/checkout@v4
 
-      - name: Install azure CLI 
+      - name: Install azure CLI and download database
         uses: Azure/CLI@v2
-      
-      - name: Download database from Azure Storage
-        shell: bash
-        run: |
-          # Login to Azure Storage
-          az storage file download --account-name ${{ secrets.STORAGE_ACCOUNT_NAME }} \
+        with: 
+          inlinescript: |
+            az storage file download --account-name ${{ secrets.STORAGE_ACCOUNT_NAME }} \
             --account-key ${{ secrets.STORAGE_ACCOUNT_KEY }} \
             --share-name database-fileshare \
             --path chirp.db \
             --dest ${{env.DOTNET_ROOT}}/database
-
+      
       - name: Upload artifacts for test job
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -136,6 +136,9 @@ jobs:
     steps: 
       - uses: actions/checkout@v4
 
+      - name: Make target directory 
+        run: mkdir -p  ${{env.ArtifactPath}}/database
+
       - name: Install azure CLI and download database
         uses: Azure/CLI@v2
         with: 


### PR DESCRIPTION
A massive problem that could occur was that we might deploy a version of the software with a migration that couldn't execute, in which case the website would be down(as the database would be in an unknown state while the app's code would expect the newest version. )

These tests are pretty crude, downloading the whole database. This is fine as long as the database is 200kb, but in a real situation you'd want to skim off a small subset of it to run these tests on.